### PR TITLE
Fix for food calculation error

### DIFF
--- a/actions/loadAmmo.ts
+++ b/actions/loadAmmo.ts
@@ -25,5 +25,4 @@ export const loadAmmo = async (
   await gh.sendDynamicTransactions(ix.ixs, true);
 
   console.log("Fleet ammo loaded!");
-  await gh.getQuattrinoBalance();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labs-ultron",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "module": "index.ts",
   "bin": "./index.js",
   "description": "...",

--- a/scripts/mining.ts
+++ b/scripts/mining.ts
@@ -175,6 +175,16 @@ export const mining = async (
         gh,
         fh
       );
+
+      await actionWrapper(
+        unloadCargo,
+        fleetPubkey,
+        Resource.Food,
+        MAX_AMOUNT,
+        gh,
+        fh
+      );
+      
       await sendNotification(NotificationMessage.MINING_SUCCESS, fleetName);
     } catch (e) {
       await sendNotification(NotificationMessage.MINING_ERROR, fleetName);


### PR DESCRIPTION
Added food unload at the end of the mining cycle.
To mediate the cost of QTTRs saved, I removed the consumption from the ammo supply